### PR TITLE
add jwt authorizer support to function

### DIFF
--- a/apigateway.tf
+++ b/apigateway.tf
@@ -60,6 +60,7 @@ resource "aws_apigatewayv2_route" "this" {
 
   authorizer_id = each.value.endpoint.authorizer != null ? aws_apigatewayv2_authorizer.this[each.value.endpoint.authorizer.name].id : null
   authorization_type = each.value.endpoint.authorizer != null ? "JWT" : null
+  authorization_scopes = try(each.value.endpoint.authorizer.type, "") == "JWT" ? each.value.endpoint.authorizer.scopes : null
 }
 
 resource "aws_lambda_permission" "api_gateway" {

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,7 @@ variable "config" {
             identity_sources = optional(set(string))
             issuer_url = optional(string)
             audience = optional(set(string))
+            scopes = optional(set(string))
           }))
         })), {})
         #     file

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,13 @@ variable "config" {
         https = optional(map(object({
           method = string
           path   = string
-          #    authorizer = optional(object({}))
+          authorizer = optional(object({
+            name = string
+            type = optional(string, "JWT")
+            identity_sources = optional(set(string))
+            issuer_url = optional(string)
+            audience = optional(set(string))
+          }))
         })), {})
         #     file
         #     log
@@ -139,6 +145,11 @@ variable "config" {
   validation {
     error_message = "Invalid http path. Path must begin with a forward slash '/'"
     condition     = try(alltrue(flatten([for function in values(var.config.function) : [for endpoint in values(function.trigger.https) : startswith(endpoint.path, "/")]])), true)
+  }
+
+  validation {
+    error_message = "Invalid http authorizer type. Valid values includes [JWT]"
+    condition = try(alltrue(flatten([for function in values(var.config.function) : [for endpoint in values(function.trigger.https) : [for authorizer in values(endpoint.authorizer.type) : contains(["JWT"], authorizer.type)]]])), true)
   }
 
   ##### .environment_variable ######


### PR DESCRIPTION
This PR adds support for JWT authorizers on http endpoints. Authorizers are unique by name, but can be reused on multiple endpoints (see example below). If two authorizers with the same name exists and they have conflicting values, the last one defined is used.

```HCL
https = {
  getall = {
    method = "GET"
    path   = "/getall"
    authorizer = {
        name = "auth"
        identity_sources = ["$request.header.Authorization"]
        issuer_url = "https://idp-metadata.application-idp.com"
        audience = ["audience"]
    }
  }
  get = {
    method = "GET"
    path   = "/get/{id}"
    authorizer = {
        name = "auth"
    }
  }
``` 