### PR TITLE
fix/fails when deleting api gateway authorizer

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -65,12 +65,12 @@ variable "config" {
           method = string
           path   = string
           authorizer = optional(object({
-            name = string
-            type = optional(string, "JWT")
+            name             = string
+            type             = optional(string, "JWT")
             identity_sources = optional(set(string))
-            issuer_url = optional(string)
-            audience = optional(set(string))
-            scopes = optional(set(string))
+            issuer_url       = optional(string)
+            audience         = optional(set(string))
+            scopes           = optional(set(string))
           }))
         })), {})
         #     file
@@ -150,7 +150,7 @@ variable "config" {
 
   validation {
     error_message = "Invalid http authorizer type. Valid values includes [JWT]"
-    condition = try(alltrue(flatten([for function in values(var.config.function) : [for endpoint in values(function.trigger.https) : [for authorizer in values(endpoint.authorizer.type) : contains(["JWT"], authorizer.type)]]])), true)
+    condition     = try(alltrue(flatten([for function in values(var.config.function) : [for endpoint in values(function.trigger.https) : [for authorizer in values(endpoint.authorizer.type) : contains(["JWT"], authorizer.type)]]])), true)
   }
 
   ##### .environment_variable ######


### PR DESCRIPTION
Fix to error that happens when destroying authorizer

```HCL
module.serverless.aws_apigatewayv2_authorizer.this["cognito-auth"]: Destroying... [id=p5lc9d]
╷
│ Error: deleting API Gateway v2 authorizer: ConflictException: Cannot delete authorizer 'cognito-auth', is referenced in route: GET /trainings
│
│
```

(see: https://github.com/hashicorp/terraform-provider-aws/issues/14812)