### PR TITLE
Feature - CORS and Auth support for ApiGatewayV1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,19 +28,15 @@ locals {
   # }
 
   enable_rest_api_gateway = length(var.restapi.endpoints) > 0 ? 1 : 0
-  # enable_rest_api_gateway = length(local.rest_endpoints) > 0 ? 1 : 0
-  # rest_endpoints = {
-  #   for value in flatten([
-  #     for func_name, func in var.functions : [
-  #       # for http_key, endpoint in func.trigger.rest : {
-  #       for  endpoint in func.trigger.rest : {
-  #         func_name     = func_name
-  #         # endpoint_name = http_key
-  #         endpoint      = endpoint
-  #       }
-  #     ]
-  #   ]) : "${value.func_name}/${value.endpoint_name}" => value
-  # }
+  rest_endpoints = {
+    for value in flatten([
+      for endpoint in var.restapi.endpoints : {
+        func_name     = endpoint.target
+        endpoint_name = endpoint.edp_name
+        endpoint      = endpoint
+      }
+    ]) : "${value.func_name}/${value.endpoint_name}" => value
+  }
 
   # binary_media_types = distinct(flatten([
   #   for func_name, func in local.config.function : flatten([

--- a/restapi.tf
+++ b/restapi.tf
@@ -378,14 +378,14 @@ resource "aws_api_gateway_integration_response" "cors" {
 
   //cors
   response_parameters = {
-    "method.response.header.Access-Control-Allow-Origin"  =  "'${var.restapi.cors_origin}'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.restapi.cors_origin}'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,OPTIONS,PUT,DELETE,PATCH'"
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
   }
 }
 
 resource "aws_api_gateway_gateway_response" "response_4xx" {
-  rest_api_id = aws_api_gateway_rest_api.restapi[0].id
+  rest_api_id   = aws_api_gateway_rest_api.restapi[0].id
   response_type = "DEFAULT_4XX"
 
   response_templates = {
@@ -398,7 +398,7 @@ resource "aws_api_gateway_gateway_response" "response_4xx" {
 }
 
 resource "aws_api_gateway_gateway_response" "response_5xx" {
-  rest_api_id = aws_api_gateway_rest_api.restapi[0].id
+  rest_api_id   = aws_api_gateway_rest_api.restapi[0].id
   response_type = "DEFAULT_5XX"
 
   response_templates = {

--- a/restapi.tf
+++ b/restapi.tf
@@ -211,7 +211,7 @@ resource "aws_api_gateway_method" "restapi" {
   resource_id          = local.restapi_resources[trimprefix(each.value.path, "/")].id
   authorization        = try(each.value.authorizer.auth, "NONE")
   authorizer_id        = try(aws_api_gateway_authorizer.restapi[one(keys(aws_api_gateway_authorizer.restapi))].id, null)
-  authorization_scopes = try(each.value.authorizer.scopes, [])
+  authorization_scopes = try(each.value.authorizer.scopes, null)
 }
 
 resource "aws_api_gateway_method_settings" "restapi" {
@@ -362,7 +362,7 @@ resource "aws_api_gateway_method_response" "cors" {
   }
 
   response_parameters = {
-    "method.response.header.Access-Control-Allow-Origin"  = true
+    "method.response.header.Access-Control-Allow-Origin"  = var.restapi.cors_origin != null ? true : false
     "method.response.header.Access-Control-Allow-Methods" = true
     "method.response.header.Access-Control-Allow-Headers" = true
   }

--- a/variables.tf
+++ b/variables.tf
@@ -109,6 +109,7 @@ variable "restapi" {
     domain     = optional(string)
     location   = optional(string, "regional") # regional, edge, private
     log_format = optional(string, "clf")
+    cors_origin = optional(string)
 
     endpoints = optional(set(object({
       method                = string

--- a/variables.tf
+++ b/variables.tf
@@ -113,15 +113,19 @@ variable "restapi" {
     endpoints = optional(set(object({
       method                = string
       path                  = string
+      edp_name              = string
       type                  = optional(string, "function") # mock, function, http
       target                = optional(string)
       loglevel              = optional(string, "info")
       throttling_rate_limit = optional(number, 100)
       authorizer = optional(object({
+        auth                  = string # CUSTOM, AWS_IAM, COGNITO_USER_POOLS
         name                  = string
-        type                  = optional(string, "JWT") # token, request
+        type                  = optional(string, "TOKEN") # token, request, COGNITO_USER_POOLS
         authorizer_cedentials = optional(string)
         ttl                   = optional(number, 60)
+        provider_arns         = optional(set(string))
+        scopes                = optional(set(string)) # only if auth = COGNITO_USER_POOLS
       }))
       binary_media_types = optional(list(string), [])
     })), [])

--- a/variables.tf
+++ b/variables.tf
@@ -106,9 +106,9 @@ variable "function" {
 
 variable "restapi" {
   type = object({
-    domain     = optional(string)
-    location   = optional(string, "regional") # regional, edge, private
-    log_format = optional(string, "clf")
+    domain      = optional(string)
+    location    = optional(string, "regional") # regional, edge, private
+    log_format  = optional(string, "clf")
     cors_origin = optional(string)
 
     endpoints = optional(set(object({

--- a/version.tf
+++ b/version.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6.0"
+  required_version = "~> 1.6"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
### Feature Added Authorization support for APIGatewayV1

Added Authorization support for apigatewayv1. Only tested with cognito_user_pools that utilizes JWT.

### Feature: Added CORS support for APIGatewayV1

Added CORS support which now enables us to specify a CORS origin with the variable `var.restapi.cors_origin`. Possible values are `"hero.techchapter.com"` or `"*"` for wild card ect.  

### Refactor: TF version constraint

Refactored tf required version constraint to minimum allowed version only (`~>1.6`). The change is done to comply with `HeRo`-project version constraint at `~>1.9.0`.

See [Best Practices](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#best-practices) for module versioning