### PR TITLE
Fix: Expanded redeployment restapiv1 dep. array

### DIFF
--- a/restapi.tf
+++ b/restapi.tf
@@ -258,7 +258,16 @@ resource "aws_api_gateway_deployment" "restapi" {
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
 
   triggers = {
-    redeployment = sha1(jsonencode(var.restapi.endpoints))
+    redeployment = sha1(jsonencode([
+      var.restapi.endpoints,
+      aws_api_gateway_method.restapi,
+      aws_api_gateway_method.cors,
+      aws_api_gateway_integration.cors,
+      aws_api_gateway_method_response.cors,
+      aws_api_gateway_integration_response.cors,
+      aws_api_gateway_gateway_response.response_4xx,
+      aws_api_gateway_gateway_response.response_5xx
+    ]))
   }
 
   lifecycle {


### PR DESCRIPTION
### Changes

`redeployment` dependency array for the resource `"aws_api_gateway_deployment" "restapi"` has been expanded to include cors and auth settings when creating a new deployment of a api gateway stage. Previously, auth and cors would not be applied to endpoints because they were missing from the dependency array. A manual deployment was required.