### PR TITLE
Refactor: Output changes and fixed missing cors variable 

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -8,9 +8,11 @@ output "kms_arn" {
 
 output "rest_api" {
   value = {
-    execution_arn = try(aws_api_gateway_rest_api.restapi[0].execution_arn, null)
-    invoke_url    = try(var.restapi.domain != null ? "https://${var.restapi.domain}/" : aws_api_gateway_stage.restapi[0].invoke_url, null)
-    domain_name   = try(aws_api_gateway_domain_name.restapi[0].regional_domain_name, null)
+    execution_arn  = try(aws_api_gateway_rest_api.restapi[0].execution_arn, null)
+    invoke_url     = try(var.restapi.domain != null ? "https://${var.restapi.domain}/" : aws_api_gateway_stage.restapi[0].invoke_url, null)
+    domain_name    = try(aws_api_gateway_domain_name.restapi[0].regional_domain_name, null)
+    api_gateway_id = aws_api_gateway_rest_api.restapi[0].id
+    stage_name     = aws_api_gateway_stage.restapi[0].stage_name
   }
 }
 

--- a/output.tf
+++ b/output.tf
@@ -10,7 +10,7 @@ output "rest_api" {
   value = {
     execution_arn = try(aws_api_gateway_rest_api.restapi[0].execution_arn, null)
     invoke_url    = try(var.restapi.domain != null ? "https://${var.restapi.domain}/" : aws_api_gateway_stage.restapi[0].invoke_url, null)
-    domain_name   = try(aws_api_gateway_domain_name.restapi[0].regional_domain_name)
+    domain_name   = try(aws_api_gateway_domain_name.restapi[0].regional_domain_name, null)
   }
 }
 

--- a/restapi.tf
+++ b/restapi.tf
@@ -371,7 +371,7 @@ resource "aws_api_gateway_method_response" "cors" {
   }
 
   response_parameters = {
-    "method.response.header.Access-Control-Allow-Origin"  = var.restapi.cors_origin != null ? true : false
+    "method.response.header.Access-Control-Allow-Origin"  = var.restapi.cors_origin != null
     "method.response.header.Access-Control-Allow-Methods" = true
     "method.response.header.Access-Control-Allow-Headers" = true
   }
@@ -387,7 +387,7 @@ resource "aws_api_gateway_integration_response" "cors" {
 
   //cors
   response_parameters = {
-    "method.response.header.Access-Control-Allow-Origin"  = "'${var.restapi.cors_origin}'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${coalesce(var.restapi.cors_origin, "_")}'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,OPTIONS,PUT,DELETE,PATCH'"
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
   }
@@ -402,7 +402,7 @@ resource "aws_api_gateway_gateway_response" "response_4xx" {
   }
 
   response_parameters = {
-    "gatewayresponse.header.Access-Control-Allow-Origin" = "'${var.restapi.cors_origin}'"
+    "gatewayresponse.header.Access-Control-Allow-Origin" = "'${coalesce(var.restapi.cors_origin, "_")}'"
   }
 }
 
@@ -415,6 +415,6 @@ resource "aws_api_gateway_gateway_response" "response_5xx" {
   }
 
   response_parameters = {
-    "gatewayresponse.header.Access-Control-Allow-Origin" = "'${var.restapi.cors_origin}'"
+    "gatewayresponse.header.Access-Control-Allow-Origin" = "'${coalesce(var.restapi.cors_origin, "_")}'"
   }
 }


### PR DESCRIPTION
#### Changes

- `var.rest_api.cors_origin` is optional, but threw an error if it was not set. This is now fixed.
- output `rest_api.domain_name` throws an error if optional `var.rest_api.domain_name` is not set. This is now fixed.
- Added `api_gateway_id` and `stage_name` to output.tf