### PR TITLE
refactor restapi authorizer

### DIFF
--- a/restapi.tf
+++ b/restapi.tf
@@ -323,14 +323,14 @@ resource "aws_api_gateway_authorizer" "restapi" {
   } : key => merge(value...) }
 
   rest_api_id                      = aws_api_gateway_rest_api.restapi[0].id
+  name                             = each.key
   type                             = each.value.type
   authorizer_result_ttl_in_seconds = try(each.value.ttl, 60)
 
   authorizer_uri = try(each.value.auth, "") == "CUSTOM" ? "arn:aws:apigateway:${local.region_name}:lambda:path/2015-03-31/functions/${each.value.lambda_arn}/invocations" : null
-  
-  provider_arns = try(each.value.type, "") == "COGNITO_USER_POOLS" ? each.value.provider_arns
-}
 
+  provider_arns = try(each.value.type, "") == "COGNITO_USER_POOLS" ? each.value.provider_arns : []
+}
 
 
 resource "aws_api_gateway_method" "cors" {

--- a/restapi.tf
+++ b/restapi.tf
@@ -324,9 +324,11 @@ resource "aws_api_gateway_authorizer" "restapi" {
 
   rest_api_id                      = aws_api_gateway_rest_api.restapi[0].id
   type                             = each.value.type
-  authorizer_result_ttl_in_seconds = each.value.ttl
-  name                             = each.key
-  provider_arns                    = each.value.provider_arns
+  authorizer_result_ttl_in_seconds = try(each.value.ttl, 60)
+
+  authorizer_uri = try(each.value.auth, "") == "CUSTOM" ? "arn:aws:apigateway:${local.region_name}:lambda:path/2015-03-31/functions/${each.value.lambda_arn}/invocations" : null
+  
+  provider_arns = try(each.value.type, "") == "COGNITO_USER_POOLS" ? each.value.provider_arns
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,7 @@ variable "restapi" {
         type                  = optional(string, "TOKEN") # token, request, COGNITO_USER_POOLS
         authorizer_cedentials = optional(string)
         ttl                   = optional(number, 60)
+        lambda_arn            = optional(string)
         provider_arns         = optional(set(string))
         scopes                = optional(set(string)) # only if auth = COGNITO_USER_POOLS
       }))


### PR DESCRIPTION
- **feat: enhance API Gateway authorizer with error handling and new lambda integration options in restapi.tf and variables.tf**
- **fix: ensure provider_arns defaults to an empty list when type is not COGNITO_USER_POOLS in restapi.tf**

Added lambda arn variable attribute and authorizer_uri to accomodate the custom request authorizer coming from HeRo project 
