### PR TITLE
feat: enhance restapi authorizer with conditional provider_arns and authorizer_uri based on type and auth settings

### DIFF
--- a/restapi.tf
+++ b/restapi.tf
@@ -326,7 +326,9 @@ resource "aws_api_gateway_authorizer" "restapi" {
   type                             = each.value.type
   authorizer_result_ttl_in_seconds = each.value.ttl
   name                             = each.key
-  provider_arns                    = each.value.provider_arns
+  provider_arns = try(each.value.type, "") == "COGNITO_USER_POOLS" ? each.value.provider_arns : []
+
+  authorizer_uri = try(each.value.auth, "") == "CUSTOM" ? "arn:aws:apigateway:${local.region_name}:lambda:path/2015-03-31/functions/${each.value.lambda_arn}/invocations" : null
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,7 @@ variable "restapi" {
         type                  = optional(string, "TOKEN") # token, request, COGNITO_USER_POOLS
         authorizer_cedentials = optional(string)
         ttl                   = optional(number, 60)
+        lambda_arn            = optional(string)
         provider_arns         = optional(set(string))
         scopes                = optional(set(string)) # only if auth = COGNITO_USER_POOLS
       }))


### PR DESCRIPTION
Have added lambda_arn in restapi variable and has set authorizer uri conditionally based on auth value. 
Additionally I have made provider arns condtionally
This is to accomodate custom lambda authorizer attachement in restapi setup
 
