### PR TITLE
feat: support openapi body for gateway api to reduce number of tf resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ locals {
         endpoint_name = endpoint.edp_name
         endpoint      = endpoint
       }
-    ]) : "${value.func_name}/${value.endpoint_name}" => value
+    ]) : "${value.endpoint.path}/${value.endpoint.method}" => value
   }
 
   # binary_media_types = distinct(flatten([

--- a/restapi.tf
+++ b/restapi.tf
@@ -1,5 +1,6 @@
 locals {
-  endpoints = { for endpoint in var.restapi.endpoints : "${endpoint.path}/${endpoint.method}" => endpoint }
+  endpoints                 = { for endpoint in var.restapi.endpoints : "${endpoint.path}/${endpoint.method}" => endpoint }
+  restapi_uses_openapi_body = var.restapi.create_routes_with_openapi_body
 
   rest_path = toset([for endpoint in var.restapi.endpoints : trimprefix(endpoint.path, "/")])
 
@@ -114,6 +115,9 @@ resource "aws_api_gateway_rest_api" "restapi" {
   name        = "${var.name_prefix}api-gw"
   description = "${var.name_prefix}api"
 
+  body              = local.restapi_uses_openapi_body ? local.restapi_openapi_body : null
+  put_rest_api_mode = local.restapi_uses_openapi_body ? "overwrite" : null
+
   disable_execute_api_endpoint = var.restapi.domain != null
   tags                         = local.default_tags
 
@@ -124,7 +128,7 @@ resource "aws_api_gateway_rest_api" "restapi" {
 
 resource "aws_api_gateway_resource" "level1" {
   for_each = { for path in local.all_paths : path => reverse(split("/", path))[0]
-  if length(split("/", path)) == 1 }
+  if length(split("/", path)) == 1 && !local.restapi_uses_openapi_body }
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   parent_id   = aws_api_gateway_rest_api.restapi[0].root_resource_id
@@ -133,7 +137,7 @@ resource "aws_api_gateway_resource" "level1" {
 
 resource "aws_api_gateway_resource" "level2" {
   for_each = { for path in local.all_paths : path => reverse(split("/", path))[0]
-  if length(split("/", path)) == 2 }
+  if length(split("/", path)) == 2 && !local.restapi_uses_openapi_body }
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   parent_id   = aws_api_gateway_resource.level1[trimsuffix(each.key, "/${each.value}")].id
@@ -142,7 +146,7 @@ resource "aws_api_gateway_resource" "level2" {
 
 resource "aws_api_gateway_resource" "level3" {
   for_each = { for path in local.all_paths : path => reverse(split("/", path))[0]
-  if length(split("/", path)) == 3 }
+  if length(split("/", path)) == 3 && !local.restapi_uses_openapi_body }
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   parent_id   = aws_api_gateway_resource.level2[trimsuffix(each.key, "/${each.value}")].id
@@ -151,7 +155,7 @@ resource "aws_api_gateway_resource" "level3" {
 
 resource "aws_api_gateway_resource" "level4" {
   for_each = { for path in local.all_paths : path => reverse(split("/", path))[0]
-  if length(split("/", path)) == 4 }
+  if length(split("/", path)) == 4 && !local.restapi_uses_openapi_body }
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   parent_id   = aws_api_gateway_resource.level3[trimsuffix(each.key, "/${each.value}")].id
@@ -160,7 +164,7 @@ resource "aws_api_gateway_resource" "level4" {
 
 resource "aws_api_gateway_resource" "level5" {
   for_each = { for path in local.all_paths : path => reverse(split("/", path))[0]
-  if length(split("/", path)) == 5 }
+  if length(split("/", path)) == 5 && !local.restapi_uses_openapi_body }
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   parent_id   = aws_api_gateway_resource.level4[trimsuffix(each.key, "/${each.value}")].id
@@ -169,7 +173,7 @@ resource "aws_api_gateway_resource" "level5" {
 
 resource "aws_api_gateway_resource" "level6" {
   for_each = { for path in local.all_paths : path => reverse(split("/", path))[0]
-  if length(split("/", path)) == 6 }
+  if length(split("/", path)) == 6 && !local.restapi_uses_openapi_body }
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   parent_id   = aws_api_gateway_resource.level5[trimsuffix(each.key, "/${each.value}")].id
@@ -178,7 +182,7 @@ resource "aws_api_gateway_resource" "level6" {
 
 resource "aws_api_gateway_resource" "level7" {
   for_each = { for path in local.all_paths : path => reverse(split("/", path))[0]
-  if length(split("/", path)) == 7 }
+  if length(split("/", path)) == 7 && !local.restapi_uses_openapi_body }
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   parent_id   = aws_api_gateway_resource.level6[trimsuffix(each.key, "/${each.value}")].id
@@ -187,7 +191,7 @@ resource "aws_api_gateway_resource" "level7" {
 
 resource "aws_api_gateway_resource" "level8" {
   for_each = { for path in local.all_paths : path => reverse(split("/", path))[0]
-  if length(split("/", path)) == 8 }
+  if length(split("/", path)) == 8 && !local.restapi_uses_openapi_body }
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   parent_id   = aws_api_gateway_resource.level7[trimsuffix(each.key, "/${each.value}")].id
@@ -196,7 +200,7 @@ resource "aws_api_gateway_resource" "level8" {
 
 resource "aws_api_gateway_resource" "level9" {
   for_each = { for path in local.all_paths : path => reverse(split("/", path))[0]
-  if length(split("/", path)) == 9 }
+  if length(split("/", path)) == 9 && !local.restapi_uses_openapi_body }
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   parent_id   = aws_api_gateway_resource.level8[trimsuffix(each.key, "/${each.value}")].id
@@ -204,7 +208,7 @@ resource "aws_api_gateway_resource" "level9" {
 }
 
 resource "aws_api_gateway_method" "restapi" {
-  for_each = local.endpoints
+  for_each = local.restapi_uses_openapi_body ? {} : local.endpoints
 
   rest_api_id          = aws_api_gateway_rest_api.restapi[0].id
   http_method          = each.value.method
@@ -215,7 +219,7 @@ resource "aws_api_gateway_method" "restapi" {
 }
 
 resource "aws_api_gateway_method_settings" "restapi" {
-  for_each = local.endpoints
+  for_each = local.restapi_uses_openapi_body ? {} : local.endpoints
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   stage_name  = aws_api_gateway_stage.restapi[0].stage_name
@@ -234,11 +238,11 @@ resource "aws_lambda_permission" "restapi" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.function[each.value].function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${split("/", aws_api_gateway_deployment.restapi[0].execution_arn)[0]}/*"
+  source_arn    = "${aws_api_gateway_rest_api.restapi[0].execution_arn}/*"
 }
 
 resource "aws_api_gateway_integration" "restapi" {
-  for_each = local.endpoints
+  for_each = local.restapi_uses_openapi_body ? {} : local.endpoints
 
   rest_api_id             = aws_api_gateway_rest_api.restapi[0].id
   resource_id             = local.restapi_resources[trimprefix(each.value.path, "/")].id
@@ -258,7 +262,13 @@ resource "aws_api_gateway_deployment" "restapi" {
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
 
   triggers = {
-    redeployment = sha1(jsonencode([
+    redeployment = local.restapi_uses_openapi_body ? sha1(jsonencode([
+      local.restapi_openapi,
+      var.restapi.log_format,
+      local.restapi_method_setting_overrides,
+      local.restapi_default_loglevel,
+      local.restapi_default_throttling_rate_limit
+      ])) : sha1(jsonencode([
       var.restapi.endpoints,
       aws_api_gateway_method.restapi,
       aws_api_gateway_method.cors,
@@ -279,6 +289,34 @@ resource "aws_api_gateway_deployment" "restapi" {
   ]
 }
 
+resource "aws_api_gateway_method_settings" "restapi_all" {
+  count = local.enable_rest_api_gateway == 1 && local.restapi_uses_openapi_body ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.restapi[0].id
+  stage_name  = aws_api_gateway_stage.restapi[0].stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled       = true
+    logging_level         = upper(local.restapi_default_loglevel)
+    throttling_rate_limit = local.restapi_default_throttling_rate_limit
+  }
+}
+
+resource "aws_api_gateway_method_settings" "restapi_openapi_overrides" {
+  for_each = local.restapi_uses_openapi_body ? local.restapi_method_setting_overrides : {}
+
+  rest_api_id = aws_api_gateway_rest_api.restapi[0].id
+  stage_name  = aws_api_gateway_stage.restapi[0].stage_name
+  method_path = "${trimprefix(each.value.path, "/")}/${each.value.method}"
+
+  settings {
+    metrics_enabled       = true
+    logging_level         = upper(each.value.loglevel)
+    throttling_rate_limit = each.value.throttling_rate_limit
+  }
+}
+
 resource "aws_api_gateway_stage" "restapi" {
   count = local.enable_rest_api_gateway
 
@@ -288,7 +326,7 @@ resource "aws_api_gateway_stage" "restapi" {
 
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.restapi[0].arn
-    format          = try(local.log_format["clf"], var.restapi.log_format)
+    format          = try(local.log_format[var.restapi.log_format], var.restapi.log_format)
   }
 }
 
@@ -313,7 +351,7 @@ resource "aws_api_gateway_base_path_mapping" "restapi" {
 }
 
 resource "aws_api_gateway_authorizer" "restapi" {
-  for_each = { for key, value in {
+  for_each = local.restapi_uses_openapi_body ? {} : { for key, value in {
     for auth in values(local.rest_endpoints)[*].endpoint.authorizer
     : auth.name => {
       for k, v in auth
@@ -334,7 +372,7 @@ resource "aws_api_gateway_authorizer" "restapi" {
 
 
 resource "aws_api_gateway_method" "cors" {
-  for_each = local.restapi_resources
+  for_each = local.restapi_uses_openapi_body ? {} : local.restapi_resources
 
   rest_api_id   = aws_api_gateway_rest_api.restapi[0].id
   resource_id   = each.value.id
@@ -343,7 +381,7 @@ resource "aws_api_gateway_method" "cors" {
 }
 
 resource "aws_api_gateway_integration" "cors" {
-  for_each = local.restapi_resources
+  for_each = local.restapi_uses_openapi_body ? {} : local.restapi_resources
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   resource_id = each.value.id
@@ -361,7 +399,7 @@ resource "aws_api_gateway_integration" "cors" {
 }
 
 resource "aws_api_gateway_method_response" "cors" {
-  for_each = local.restapi_resources
+  for_each = local.restapi_uses_openapi_body ? {} : local.restapi_resources
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   resource_id = each.value.id
@@ -380,7 +418,7 @@ resource "aws_api_gateway_method_response" "cors" {
 }
 
 resource "aws_api_gateway_integration_response" "cors" {
-  for_each = local.restapi_resources
+  for_each = local.restapi_uses_openapi_body ? {} : local.restapi_resources
 
   rest_api_id = aws_api_gateway_rest_api.restapi[0].id
   resource_id = each.value.id
@@ -396,7 +434,7 @@ resource "aws_api_gateway_integration_response" "cors" {
 }
 
 resource "aws_api_gateway_gateway_response" "response_4xx" {
-  count = local.enable_rest_api_gateway
+  count = local.enable_rest_api_gateway == 1 && !local.restapi_uses_openapi_body ? 1 : 0
 
   rest_api_id   = aws_api_gateway_rest_api.restapi[0].id
   response_type = "DEFAULT_4XX"
@@ -411,7 +449,7 @@ resource "aws_api_gateway_gateway_response" "response_4xx" {
 }
 
 resource "aws_api_gateway_gateway_response" "response_5xx" {
-  count = local.enable_rest_api_gateway
+  count = local.enable_rest_api_gateway == 1 && !local.restapi_uses_openapi_body ? 1 : 0
 
   rest_api_id   = aws_api_gateway_rest_api.restapi[0].id
   response_type = "DEFAULT_5XX"

--- a/restapi_openapi.tf
+++ b/restapi_openapi.tf
@@ -98,13 +98,13 @@ locals {
         description = "CORS support"
         headers = {
           "Access-Control-Allow-Origin" = {
-            schema = { type = "string" }
+            type = "string"
           }
           "Access-Control-Allow-Methods" = {
-            schema = { type = "string" }
+            type = "string"
           }
           "Access-Control-Allow-Headers" = {
-            schema = { type = "string" }
+            type = "string"
           }
         }
       }
@@ -164,7 +164,7 @@ locals {
 
   restapi_openapi = merge(
     {
-      openapi = "3.0.1"
+      swagger = "2.0"
       info = {
         title   = "${var.name_prefix}api-gw"
         version = "1.0"
@@ -172,9 +172,7 @@ locals {
       paths = local.restapi_openapi_paths
     },
     jsondecode(length(local.restapi_security_schemes) > 0 ? jsonencode({
-      components = {
-        securitySchemes = local.restapi_security_schemes
-      }
+      securityDefinitions = local.restapi_security_schemes
     }) : "{}"),
     jsondecode(var.restapi.cors_origin != null ? jsonencode({
       x-amazon-apigateway-gateway-responses = local.restapi_gateway_responses

--- a/restapi_openapi.tf
+++ b/restapi_openapi.tf
@@ -33,26 +33,25 @@ locals {
         in                           = "header"
         x-amazon-apigateway-authtype = upper(authorizer.auth) == "AWS_IAM" ? "awsSigv4" : lower(authorizer.auth) == "cognito_user_pools" ? "cognito_user_pools" : lower(authorizer.auth)
       },
-      upper(authorizer.auth) == "AWS_IAM" ? {} :
-      {
+      jsondecode(upper(authorizer.auth) == "AWS_IAM" ? "{}" : jsonencode({
         x-amazon-apigateway-authorizer = merge(
           {
             type = upper(authorizer.auth) == "COGNITO_USER_POOLS" ? "cognito_user_pools" : lower(authorizer.type)
           },
-          try(authorizer.provider_arns, null) != null ? {
+          jsondecode(try(authorizer.provider_arns, null) != null ? jsonencode({
             providerARNs = tolist(authorizer.provider_arns)
-          } : {},
-          try(authorizer.lambda_arn, null) != null ? {
+          }) : "{}"),
+          jsondecode(try(authorizer.lambda_arn, null) != null ? jsonencode({
             authorizerUri = "arn:aws:apigateway:${local.region_name}:lambda:path/2015-03-31/functions/${authorizer.lambda_arn}/invocations"
-          } : {},
-          try(authorizer.authorizer_cedentials, null) != null ? {
+          }) : "{}"),
+          jsondecode(try(authorizer.authorizer_cedentials, null) != null ? jsonencode({
             authorizerCredentials = authorizer.authorizer_cedentials
-          } : {},
-          try(authorizer.ttl, null) != null ? {
+          }) : "{}"),
+          jsondecode(try(authorizer.ttl, null) != null ? jsonencode({
             authorizerResultTtlInSeconds = authorizer.ttl
-          } : {}
+          }) : "{}")
         )
-      }
+      }))
     )
   }
 
@@ -66,15 +65,15 @@ locals {
           }
         }
       },
-      endpoint.authorizer != null ? {
+      jsondecode(endpoint.authorizer != null ? jsonencode({
         security = [
           {
             (endpoint.authorizer.name) = try(endpoint.authorizer.scopes, null) != null ? tolist(endpoint.authorizer.scopes) : []
           }
         ]
-      } : {},
+      }) : "{}"),
       {
-        x-amazon-apigateway-integration = endpoint.type == "mock" ? {
+        x-amazon-apigateway-integration = jsondecode(endpoint.type == "mock" ? jsonencode({
           type = "mock"
           requestTemplates = {
             "application/json" = jsonencode({ statusCode = 200 })
@@ -84,11 +83,11 @@ locals {
               statusCode = "200"
             }
           }
-          } : {
+          }) : jsonencode({
           type       = "aws_proxy"
           httpMethod = "POST"
           uri        = aws_lambda_function.function[endpoint.target].invoke_arn
-        }
+        }))
       }
     )
   }
@@ -119,7 +118,7 @@ locals {
         default = {
           statusCode = "200"
           responseParameters = {
-            "method.response.header.Access-Control-Allow-Origin"  = "'${var.restapi.cors_origin}'"
+            "method.response.header.Access-Control-Allow-Origin"  = "'${coalesce(var.restapi.cors_origin, "_")}'"
             "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,OPTIONS,PUT,DELETE,PATCH'"
             "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
           }
@@ -131,9 +130,9 @@ locals {
   restapi_openapi_paths = {
     for path in local.restapi_endpoint_paths :
     path => merge(
-      var.restapi.cors_origin != null && !contains(local.restapi_paths_with_options, path) ? {
+      jsondecode(var.restapi.cors_origin != null && !contains(local.restapi_paths_with_options, path) ? jsonencode({
         options = local.restapi_openapi_cors_operation
-      } : {},
+      }) : "{}"),
       merge([
         for endpoint in var.restapi.endpoints :
         {
@@ -147,7 +146,7 @@ locals {
   restapi_gateway_responses = {
     DEFAULT_4XX = {
       responseParameters = {
-        "gatewayresponse.header.Access-Control-Allow-Origin" = "'${var.restapi.cors_origin}'"
+        "gatewayresponse.header.Access-Control-Allow-Origin" = "'${coalesce(var.restapi.cors_origin, "_")}'"
       }
       responseTemplates = {
         "application/json" = "{'message':$context.error.messageString}"
@@ -155,7 +154,7 @@ locals {
     }
     DEFAULT_5XX = {
       responseParameters = {
-        "gatewayresponse.header.Access-Control-Allow-Origin" = "'${var.restapi.cors_origin}'"
+        "gatewayresponse.header.Access-Control-Allow-Origin" = "'${coalesce(var.restapi.cors_origin, "_")}'"
       }
       responseTemplates = {
         "application/json" = "{'message':$context.error.messageString}"
@@ -172,14 +171,14 @@ locals {
       }
       paths = local.restapi_openapi_paths
     },
-    length(local.restapi_security_schemes) > 0 ? {
+    jsondecode(length(local.restapi_security_schemes) > 0 ? jsonencode({
       components = {
         securitySchemes = local.restapi_security_schemes
       }
-    } : {},
-    var.restapi.cors_origin != null ? {
+    }) : "{}"),
+    jsondecode(var.restapi.cors_origin != null ? jsonencode({
       x-amazon-apigateway-gateway-responses = local.restapi_gateway_responses
-    } : {}
+    }) : "{}")
   )
 
   restapi_openapi_body = jsonencode(local.restapi_openapi)

--- a/restapi_openapi.tf
+++ b/restapi_openapi.tf
@@ -1,0 +1,186 @@
+locals {
+  restapi_default_endpoint_key          = try(sort(keys(local.endpoints))[0], null)
+  restapi_default_loglevel              = try(local.endpoints[local.restapi_default_endpoint_key].loglevel, "info")
+  restapi_default_throttling_rate_limit = try(local.endpoints[local.restapi_default_endpoint_key].throttling_rate_limit, 100)
+  restapi_method_setting_overrides = {
+    for key, endpoint in local.endpoints : key => endpoint
+    if upper(endpoint.loglevel) != upper(local.restapi_default_loglevel) || endpoint.throttling_rate_limit != local.restapi_default_throttling_rate_limit
+  }
+
+  restapi_endpoint_paths = toset([
+    for endpoint in var.restapi.endpoints : endpoint.path
+  ])
+
+  restapi_paths_with_options = toset([
+    for endpoint in var.restapi.endpoints : endpoint.path
+    if upper(endpoint.method) == "OPTIONS"
+  ])
+
+  restapi_authorizers = {
+    for key, value in {
+      for endpoint in var.restapi.endpoints :
+      endpoint.authorizer.name => endpoint.authorizer...
+      if endpoint.authorizer != null
+    } : key => merge(value...)
+  }
+
+  restapi_security_schemes = {
+    for name, authorizer in local.restapi_authorizers :
+    name => merge(
+      {
+        type                         = "apiKey"
+        name                         = "Authorization"
+        in                           = "header"
+        x-amazon-apigateway-authtype = upper(authorizer.auth) == "AWS_IAM" ? "awsSigv4" : lower(authorizer.auth) == "cognito_user_pools" ? "cognito_user_pools" : lower(authorizer.auth)
+      },
+      upper(authorizer.auth) == "AWS_IAM" ? {} :
+      {
+        x-amazon-apigateway-authorizer = merge(
+          {
+            type = upper(authorizer.auth) == "COGNITO_USER_POOLS" ? "cognito_user_pools" : lower(authorizer.type)
+          },
+          try(authorizer.provider_arns, null) != null ? {
+            providerARNs = tolist(authorizer.provider_arns)
+          } : {},
+          try(authorizer.lambda_arn, null) != null ? {
+            authorizerUri = "arn:aws:apigateway:${local.region_name}:lambda:path/2015-03-31/functions/${authorizer.lambda_arn}/invocations"
+          } : {},
+          try(authorizer.authorizer_cedentials, null) != null ? {
+            authorizerCredentials = authorizer.authorizer_cedentials
+          } : {},
+          try(authorizer.ttl, null) != null ? {
+            authorizerResultTtlInSeconds = authorizer.ttl
+          } : {}
+        )
+      }
+    )
+  }
+
+  restapi_openapi_operations = {
+    for endpoint in var.restapi.endpoints :
+    "${endpoint.path}/${endpoint.method}" => merge(
+      {
+        responses = {
+          "200" = {
+            description = "OK"
+          }
+        }
+      },
+      endpoint.authorizer != null ? {
+        security = [
+          {
+            (endpoint.authorizer.name) = try(endpoint.authorizer.scopes, null) != null ? tolist(endpoint.authorizer.scopes) : []
+          }
+        ]
+      } : {},
+      {
+        x-amazon-apigateway-integration = endpoint.type == "mock" ? {
+          type = "mock"
+          requestTemplates = {
+            "application/json" = jsonencode({ statusCode = 200 })
+          }
+          responses = {
+            default = {
+              statusCode = "200"
+            }
+          }
+          } : {
+          type       = "aws_proxy"
+          httpMethod = "POST"
+          uri        = aws_lambda_function.function[endpoint.target].invoke_arn
+        }
+      }
+    )
+  }
+
+  restapi_openapi_cors_operation = {
+    responses = {
+      "200" = {
+        description = "CORS support"
+        headers = {
+          "Access-Control-Allow-Origin" = {
+            schema = { type = "string" }
+          }
+          "Access-Control-Allow-Methods" = {
+            schema = { type = "string" }
+          }
+          "Access-Control-Allow-Headers" = {
+            schema = { type = "string" }
+          }
+        }
+      }
+    }
+    x-amazon-apigateway-integration = {
+      type = "mock"
+      requestTemplates = {
+        "application/json" = jsonencode({ statusCode = 200 })
+      }
+      responses = {
+        default = {
+          statusCode = "200"
+          responseParameters = {
+            "method.response.header.Access-Control-Allow-Origin"  = "'${var.restapi.cors_origin}'"
+            "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,OPTIONS,PUT,DELETE,PATCH'"
+            "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+          }
+        }
+      }
+    }
+  }
+
+  restapi_openapi_paths = {
+    for path in local.restapi_endpoint_paths :
+    path => merge(
+      var.restapi.cors_origin != null && !contains(local.restapi_paths_with_options, path) ? {
+        options = local.restapi_openapi_cors_operation
+      } : {},
+      merge([
+        for endpoint in var.restapi.endpoints :
+        {
+          (upper(endpoint.method) == "ANY" ? "x-amazon-apigateway-any-method" : lower(endpoint.method)) = local.restapi_openapi_operations["${endpoint.path}/${endpoint.method}"]
+        }
+        if endpoint.path == path
+      ]...)
+    )
+  }
+
+  restapi_gateway_responses = {
+    DEFAULT_4XX = {
+      responseParameters = {
+        "gatewayresponse.header.Access-Control-Allow-Origin" = "'${var.restapi.cors_origin}'"
+      }
+      responseTemplates = {
+        "application/json" = "{'message':$context.error.messageString}"
+      }
+    }
+    DEFAULT_5XX = {
+      responseParameters = {
+        "gatewayresponse.header.Access-Control-Allow-Origin" = "'${var.restapi.cors_origin}'"
+      }
+      responseTemplates = {
+        "application/json" = "{'message':$context.error.messageString}"
+      }
+    }
+  }
+
+  restapi_openapi = merge(
+    {
+      openapi = "3.0.1"
+      info = {
+        title   = "${var.name_prefix}api-gw"
+        version = "1.0"
+      }
+      paths = local.restapi_openapi_paths
+    },
+    length(local.restapi_security_schemes) > 0 ? {
+      components = {
+        securitySchemes = local.restapi_security_schemes
+      }
+    } : {},
+    var.restapi.cors_origin != null ? {
+      x-amazon-apigateway-gateway-responses = local.restapi_gateway_responses
+    } : {}
+  )
+
+  restapi_openapi_body = jsonencode(local.restapi_openapi)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -106,10 +106,11 @@ variable "function" {
 
 variable "restapi" {
   type = object({
-    domain      = optional(string)
-    location    = optional(string, "regional") # regional, edge, private
-    log_format  = optional(string, "clf")
-    cors_origin = optional(string)
+    domain                          = optional(string)
+    location                        = optional(string, "regional") # regional, edge, private
+    log_format                      = optional(string, "clf")
+    cors_origin                     = optional(string)
+    create_routes_with_openapi_body = optional(bool, false)
 
     endpoints = optional(set(object({
       method                = string
@@ -133,6 +134,11 @@ variable "restapi" {
     })), [])
   })
   default = {}
+
+  validation {
+    error_message = "`restapi.create_routes_with_openapi_body` currently supports endpoint types [function, mock]."
+    condition     = !var.restapi.create_routes_with_openapi_body || try(alltrue([for endpoint in var.restapi.endpoints : contains(["function", "mock"], endpoint.type)]), true)
+  }
 
   #   firewall = optional(object({
   #     block_by_default = optional(bool, false)


### PR DESCRIPTION
## Why

Terraform plans for consumers of this module have become slow because every REST API route is expanded into many separate API Gateway Terraform resources: path resources, methods, integrations, CORS methods/responses, gateway responses, authorizers, and per-method settings. For large APIs, Terraform has to refresh and diff a large graph even when the caller only changed application code or a small endpoint detail.

This change adds an opt-in path where API Gateway route shape is owned by the REST API body instead. Callers can keep the existing `restapi.endpoints` contract, but when `restapi.create_routes_with_openapi_body = true`, the module generates the API definition and assigns it to `aws_api_gateway_rest_api.restapi.body`. That lets Terraform manage the REST API shape through one resource instead of many route-level resources, while keeping the default behavior unchanged for existing environments.

This makes `tf plan` much faster if API Gateway has a large number of routes.

## Summary

- Add `restapi.create_routes_with_openapi_body` to opt into API-definition-owned REST Gateway routes.
- Generate REST API paths, Lambda proxy/mock integrations, CORS, gateway responses, authorizers, and method security from existing `restapi.endpoints`.
- Disable granular API Gateway route/method/integration/CORS/authorizer resources only in OpenAPI body mode to avoid Terraform/API Gateway ownership conflicts.
- Preserve Lambda permissions, custom domains, stages, access logs, and method settings outside the route shape.
- Handle Cognito scopes, IAM auth, `ANY` methods, mock endpoints, and null CORS values in the generated document.
